### PR TITLE
Adds support for fat arrow functions.

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -36,7 +36,8 @@ exports.container = function () {
         fileEnding: /\.\w+$/,
         dashes: /\-(\w)/g,
         scriptFiles: /\.(js|coffee)$/,
-        strFunc: /[function.*]?\(([\s\S]*?)\)/
+        strFunc: /function.+\(([\s\S]*?)\)/,
+        strFuncES6: /\(([\s\S]*?)\)\s*\=>/
     };
 
     // Define a list of factory names which should be blacklisted e.g. in method "find"
@@ -414,11 +415,16 @@ exports.container = function () {
      * @protected
      */
     var argList = function (func) {
-        // match over multiple lines
+        // Normal ES5 function check
         var match = func.toString().match(regex.strFunc);
 
         if (!match) {
-            throw new Error('Could not parse function arguments: ' + func.toString());
+            // ES6 fat arrow function check
+            match = func.toString().match(regex.strFuncES6);
+
+            if (!match) {
+                throw new Error('Could not parse function arguments: ' + func.toString());
+            }
         }
 
         return match[1].split(',')

--- a/source/index.js
+++ b/source/index.js
@@ -36,7 +36,7 @@ exports.container = function () {
         fileEnding: /\.\w+$/,
         dashes: /\-(\w)/g,
         scriptFiles: /\.(js|coffee)$/,
-        strFunc: /function.*?\(([\s\S]*?)\)/
+        strFunc: /[function.*]?\(([\s\S]*?)\)/
     };
 
     // Define a list of factory names which should be blacklisted e.g. in method "find"

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1103,6 +1103,34 @@ describe('inject', function () {
                     });
                 });
             });
+            it('should read dependencies from a multi line ES6 fat arrow function', function (done) {
+                var afile = path.join(os.tmpDir(), 'AA1.js');
+                var acode = 'module.exports = () => {\nreturn "a";\n}\n';
+                testFiles.push(afile);
+
+                var bfile = path.join(os.tmpDir(), 'BB1.js');
+                var bcode = 'module.exports = (\nAA1\n) => {\nreturn AA1 + "b";\n}\n';
+                testFiles.push(bfile);
+
+                fs.writeFile(afile, acode, function (err) {
+                    assert.ifError(err);
+
+                    container.load(afile);
+
+                    var a = container.get('AA1');
+                    assert.equal(a, 'a');
+
+                    fs.writeFile(bfile, bcode, function (err) {
+                        assert.ifError(err);
+
+                        container.load(bfile);
+                        var b = container.get('BB1');
+                        assert.equal(b, 'ab');
+
+                        done();
+                    });
+                });
+            });
         });
     });
 


### PR DESCRIPTION
Hey! Noticed you've been doing a lot of work over here. I've switch over to your fork. How do you feel about supporting fat arrow functions? This change to the `strFunc` regex seems to be working for me and all the tests are still passing.

```js
// es6 fat arrow
container.register('_', () => require('lodash'));
// vs es5
container.register('_', function() { 
  return require('lodash'); 
});
```

without this change use of fat arrow functions will throw an error:

```shell
throw new Error('Could not parse function arguments: ' + func.toString());
Error: Could not parse function arguments: () => require('lodash')
```

Good work so far and let me know what's up! 🍻 